### PR TITLE
fix: Update libexpat1 in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN poetry build && /venv/bin/pip install dist/*.whl
 
 # Multi-stage example
 FROM base as final
+
+# Fix CVE-2024-45490, CVE-2024-45491, CVE-2024-45492 in base image.
+RUN apt-get update && apt-get install -y --no-install-recommends libexpat1=2.5.0-1+deb12u1
+
 COPY --from=develop /venv /venv
 COPY docker-entrypoint.sh ./
 CMD ["./docker-entrypoint.sh"]


### PR DESCRIPTION
Update `libexpat1` to `2.5.0-1+deb12u1` to fix CVE-2024-45490, CVE-2024-45491, CVE-2024-45492.