### PR TITLE
test: Use in-memory SQLite for tests

### DIFF
--- a/src/flaskr/__init__.py
+++ b/src/flaskr/__init__.py
@@ -7,8 +7,6 @@ from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
 
-# fix: bump for uv release
-
 # =============================
 # Application Factory function
 # =============================
@@ -27,8 +25,9 @@ def create_app(test_config=None):
             default=f"sqlite:///{os.path.join(app.instance_path, 'flaskr.db')}",
         ),
     )
-    # config_type = os.getenv("CONFIG_TYPE", default="config.TestingConfig")
-    # app.config.from_object(config_type)
+
+    if test_config is not None:
+        app.config.update(test_config)
 
     initialize_extensions(app)
     register_blueprints(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,17 +6,16 @@ from flaskr import create_app, db
 from flaskr.models import Post, User
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def test_client():
-    os.environ["CONFIG_TYPE"] = "config.TestingConfig"
-    app = create_app()
+    app = create_app({"SQLALCHEMY_DATABASE_URI": "sqlite://"})
 
     with app.test_client() as testing_client:
         with app.app_context():
             yield testing_client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def init_database(test_client):
     db.create_all()
 
@@ -38,7 +37,7 @@ def init_database(test_client):
     db.drop_all()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def log_in_default_user(test_client):
     test_client.post(
         "/auth/login", data={"username": "michaelr", "password": "password"}
@@ -49,7 +48,7 @@ def log_in_default_user(test_client):
     test_client.get("/auth/logout")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def cli_test_client():
     os.environ["CONFIG_TYPE"] = "config.TestingConfig"
     app = create_app()


### PR DESCRIPTION
Tests were using the database in the instance folder, causing failures when it already contained data.